### PR TITLE
feat(apiserver): add CAMB AI as TTS engine

### DIFF
--- a/config/integrations.example.json
+++ b/config/integrations.example.json
@@ -51,6 +51,14 @@
     }
   },
   {
+    "name": "CAMB AI TTS",
+    "productRef": "tts.cambai",
+    "type": "tts",
+    "credentials": {
+      "apiKey": "REDACTED"
+    }
+  },
+  {
     "name": "Groq Large Language Models",
     "productRef": "llm.groq",
     "type": "llm",

--- a/mods/apiserver/migrations/20260410045143_add_cambai_vendor/migration.sql
+++ b/mods/apiserver/migrations/20260410045143_add_cambai_vendor/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "product_vendors" ADD VALUE 'CAMB_AI';

--- a/mods/apiserver/schema.prisma
+++ b/mods/apiserver/schema.prisma
@@ -134,6 +134,7 @@ enum ProductVendor {
   GROQ
   ANTHROPIC
   ELEVEN_LABS
+  CAMB_AI
   GENERIC
 
   // Maps

--- a/mods/apiserver/src/core/seed.ts
+++ b/mods/apiserver/src/core/seed.ts
@@ -91,6 +91,17 @@ async function main() {
   });
 
   await prisma.product.upsert({
+    where: { ref: "tts.cambai" },
+    update: {},
+    create: {
+      ref: "tts.cambai",
+      name: "CAMB AI Text-to-Speech",
+      vendor: "CAMB_AI",
+      type: "TTS"
+    }
+  });
+
+  await prisma.product.upsert({
     where: { ref: "llm.openai" },
     update: {},
     create: {

--- a/mods/apiserver/src/voice/tts/CambAi.ts
+++ b/mods/apiserver/src/voice/tts/CambAi.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Readable } from "stream";
+import { getLogger } from "@fonoster/logger";
+import * as z from "zod";
+import { AbstractTextToSpeech } from "./AbstractTextToSpeech";
+import { CambAiTtsConfig, SynthOptions } from "./types";
+import { createChunkedSynthesisStream } from "./utils/createChunkedSynthesisStream";
+
+const logger = getLogger({ service: "apiserver", filePath: __filename });
+const ENGINE_NAME = "tts.cambai";
+
+// CAMB AI streaming TTS endpoint
+const CAMB_AI_TTS_STREAM_URL = "https://client.camb.ai/apis/tts-stream";
+
+class CambAi extends AbstractTextToSpeech<typeof ENGINE_NAME> {
+  engineConfig: CambAiTtsConfig;
+  readonly engineName = ENGINE_NAME;
+  protected readonly OUTPUT_FORMAT = "sln16";
+  protected readonly CACHING_FIELDS = ["voice", "model", "language", "text"];
+
+  constructor(config: CambAiTtsConfig) {
+    super();
+    this.engineConfig = config;
+  }
+
+  synthesize(
+    text: string,
+    options: SynthOptions
+  ): { ref: string; stream: Readable } {
+    this.logSynthesisRequest(text, options);
+
+    const { voice, model, language } = this.engineConfig.config;
+    const ref = this.createMediaReference();
+
+    const stream = createChunkedSynthesisStream(text, async (chunkText) => {
+      try {
+        const response = await fetch(CAMB_AI_TTS_STREAM_URL, {
+          method: "POST",
+          headers: {
+            "x-api-key": this.engineConfig.credentials.apiKey,
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            text: chunkText,
+            voice_id: parseInt(voice, 10),
+            language: language ?? "en-us",
+            speech_model: model ?? "mars-flash",
+            output_configuration: { format: "wav" }
+          })
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(
+            `CAMB AI TTS API error ${response.status}: ${errorText}`
+          );
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        const audioBuffer = Buffer.from(arrayBuffer);
+
+        // Skip the 44-byte WAV header to get raw PCM16 data
+        return audioBuffer.subarray(44);
+      } catch (error) {
+        logger.error(`error in CAMB AI synthesis: ${error.message}`, {
+          stack: error.stack
+        });
+        throw error;
+      }
+    });
+
+    return { ref, stream };
+  }
+
+  static getConfigValidationSchema(): z.Schema {
+    return z.object({
+      voice: z.string().optional(),
+      model: z.enum(["mars-flash", "mars-pro", "mars-instruct"]).optional(),
+      language: z.string().optional()
+    });
+  }
+
+  static getCredentialsValidationSchema(): z.Schema {
+    return z.object({
+      apiKey: z.string()
+    });
+  }
+}
+
+export { ENGINE_NAME, CambAi };

--- a/mods/apiserver/src/voice/tts/TextToSpeechFactory.ts
+++ b/mods/apiserver/src/voice/tts/TextToSpeechFactory.ts
@@ -19,6 +19,7 @@
 import { getLogger } from "@fonoster/logger";
 import { AbstractTextToSpeech } from "./AbstractTextToSpeech";
 import { Azure, ENGINE_NAME as AZURE_ENGINE_NAME } from "./Azure";
+import { ENGINE_NAME as CAMB_AI_ENGINE_NAME, CambAi } from "./CambAi";
 import { Deepgram, ENGINE_NAME as DEEPGRAM_ENGINE_NAME } from "./Deepgram";
 import {
   ENGINE_NAME as ELEVEN_LABS_ENGINE_NAME,
@@ -54,6 +55,7 @@ class TextToSpeechFactory {
 // Register engines
 TextToSpeechFactory.registerEngine(GOOGLE_ENGINE_NAME, Google);
 TextToSpeechFactory.registerEngine(AZURE_ENGINE_NAME, Azure);
+TextToSpeechFactory.registerEngine(CAMB_AI_ENGINE_NAME, CambAi);
 TextToSpeechFactory.registerEngine(DEEPGRAM_ENGINE_NAME, Deepgram);
 TextToSpeechFactory.registerEngine(ELEVEN_LABS_ENGINE_NAME, ElevenLabs);
 

--- a/mods/apiserver/src/voice/tts/types.ts
+++ b/mods/apiserver/src/voice/tts/types.ts
@@ -50,9 +50,17 @@ type AzureTTSConfig = {
   };
 };
 
+type CambAiTtsConfig = {
+  [key: string]: Record<string, string>;
+  credentials: {
+    apiKey: string;
+  };
+};
+
 export {
   SynthOptions,
   AzureTTSConfig,
+  CambAiTtsConfig,
   DeepgramTtsConfig,
   ElevenLabsTtsConfig,
   GoogleTtsConfig

--- a/mods/apiserver/test/voice/tts/cambAi.test.ts
+++ b/mods/apiserver/test/voice/tts/cambAi.test.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from "chai";
+import { createSandbox, SinonStub } from "sinon";
+import { Readable } from "stream";
+import { CambAi, ENGINE_NAME } from "../../../src/voice/tts/CambAi";
+import { TextToSpeechFactory } from "../../../src/voice/tts/TextToSpeechFactory";
+import { CambAiTtsConfig } from "../../../src/voice/tts/types";
+
+const sandbox = createSandbox();
+
+function createTestConfig(overrides: Partial<CambAiTtsConfig> = {}): CambAiTtsConfig {
+  return {
+    credentials: { apiKey: "test-api-key" },
+    config: {
+      voice: "147320",
+      model: "mars-flash",
+      language: "en-us"
+    },
+    ...overrides
+  } as CambAiTtsConfig;
+}
+
+// Build a minimal WAV buffer: 44-byte header + PCM16 payload
+function buildWavBuffer(pcmBytes: number): Buffer {
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcmBytes, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20); // PCM
+  header.writeUInt16LE(1, 22); // mono
+  header.writeUInt32LE(24000, 24); // sample rate
+  header.writeUInt32LE(48000, 28); // byte rate
+  header.writeUInt16LE(2, 32); // block align
+  header.writeUInt16LE(16, 34); // bits per sample
+  header.write("data", 36);
+  header.writeUInt32LE(pcmBytes, 40);
+  const pcm = Buffer.alloc(pcmBytes, 0x10); // non-silent PCM
+  return Buffer.concat([header, pcm]);
+}
+
+describe("@voice/tts/CambAi", function () {
+  let fetchStub: SinonStub;
+
+  beforeEach(function () {
+    fetchStub = sandbox.stub(global, "fetch");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should have the correct engine name", function () {
+    expect(ENGINE_NAME).to.equal("tts.cambai");
+  });
+
+  it("should create an instance with correct config", function () {
+    const config = createTestConfig();
+    const engine = new CambAi(config);
+    expect(engine.getName()).to.equal("tts.cambai");
+  });
+
+  it("should send correct payload to CAMB AI API", async function () {
+    const wavBuffer = buildWavBuffer(960); // 480 samples of PCM16
+    fetchStub.resolves(new Response(wavBuffer, { status: 200 }));
+
+    const config = createTestConfig();
+    const engine = new CambAi(config);
+    const { stream } = engine.synthesize("Hello from test", { voice: "147320" });
+
+    // Consume stream to trigger the fetch
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+      stream.on("end", resolve);
+      stream.on("error", reject);
+    });
+
+    expect(fetchStub.calledOnce).to.be.true;
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).to.equal("https://client.camb.ai/apis/tts-stream");
+
+    const body = JSON.parse(options.body);
+    expect(body.text).to.equal("Hello from test");
+    expect(body.voice_id).to.equal(147320);
+    expect(body.language).to.equal("en-us");
+    expect(body.speech_model).to.equal("mars-flash");
+    expect(body.output_configuration).to.deep.equal({ format: "wav" });
+    expect(options.headers["x-api-key"]).to.equal("test-api-key");
+  });
+
+  it("should strip WAV header from response", async function () {
+    const pcmSize = 480; // bytes of PCM data
+    const wavBuffer = buildWavBuffer(pcmSize);
+    fetchStub.resolves(new Response(wavBuffer, { status: 200 }));
+
+    const config = createTestConfig();
+    const engine = new CambAi(config);
+    const { ref, stream } = engine.synthesize("Test", { voice: "147320" });
+
+    expect(ref).to.be.a("string");
+
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+      stream.on("end", resolve);
+      stream.on("error", reject);
+    });
+
+    const result = Buffer.concat(chunks);
+    // Result should be PCM data without the 44-byte WAV header
+    expect(result.length).to.equal(pcmSize);
+  });
+
+  it("should propagate API errors", async function () {
+    fetchStub.resolves(
+      new Response('{"error": "unauthorized"}', { status: 401 })
+    );
+
+    const config = createTestConfig();
+    const engine = new CambAi(config);
+    const { stream } = engine.synthesize("Error test", { voice: "147320" });
+
+    return new Promise<void>((resolve) => {
+      stream.on("error", (err: Error) => {
+        expect(err.message).to.include("401");
+        resolve();
+      });
+      stream.on("data", () => {}); // consume to trigger
+    });
+  });
+
+  it("should use mars-pro model when configured", async function () {
+    const wavBuffer = buildWavBuffer(960);
+    fetchStub.resolves(new Response(wavBuffer, { status: 200 }));
+
+    const config = createTestConfig();
+    config.config.model = "mars-pro";
+    const engine = new CambAi(config);
+    const { stream } = engine.synthesize("Quality test", { voice: "147320" });
+
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", () => {});
+      stream.on("end", resolve);
+      stream.on("error", reject);
+    });
+
+    const body = JSON.parse(fetchStub.firstCall.args[1].body);
+    expect(body.speech_model).to.equal("mars-pro");
+  });
+
+  it("should validate config schema", function () {
+    const schema = CambAi.getConfigValidationSchema();
+    // Valid config
+    expect(() => schema.parse({ voice: "147320", model: "mars-flash" })).to.not
+      .throw;
+    // Invalid model should fail
+    expect(() =>
+      schema.parse({ model: "invalid-model" })
+    ).to.throw;
+  });
+
+  it("should validate credentials schema", function () {
+    const schema = CambAi.getCredentialsValidationSchema();
+    expect(() => schema.parse({ apiKey: "test-key" })).to.not.throw;
+    expect(() => schema.parse({})).to.throw;
+  });
+});
+
+describe("@voice/tts/TextToSpeechFactory - CambAi", function () {
+  it("should return a CambAi instance for tts.cambai", function () {
+    const config = createTestConfig();
+    const engine = TextToSpeechFactory.getEngine("tts.cambai", config);
+    expect(engine.getName()).to.equal("tts.cambai");
+    expect(engine).to.be.an.instanceOf(CambAi);
+  });
+
+  it("should throw for unknown engine", function () {
+    expect(() =>
+      TextToSpeechFactory.getEngine("tts.nonexistent", {})
+    ).to.throw("Engine tts.nonexistent not found");
+  });
+});
+
+describe("@voice/tts/CambAi - Integration", function () {
+  it("should synthesize speech with real API", async function () {
+    const apiKey = process.env.CAMB_API_KEY;
+    if (!apiKey) {
+      this.skip();
+      return;
+    }
+
+    const config: CambAiTtsConfig = {
+      credentials: { apiKey },
+      config: {
+        voice: "147320",
+        model: "mars-flash",
+        language: "en-us"
+      }
+    } as CambAiTtsConfig;
+
+    const engine = new CambAi(config);
+    const { ref, stream } = engine.synthesize("Hello from Fonoster test.", {
+      voice: "147320"
+    });
+
+    expect(ref).to.be.a("string");
+
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+      stream.on("end", resolve);
+      stream.on("error", reject);
+    });
+
+    const result = Buffer.concat(chunks);
+    expect(result.length).to.be.greaterThan(100);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds CAMB AI as a TTS engine option for the Say verb. CAMB AI is the localization engine of choice for brands like the Premier League, NBA, NASCAR, and the Australian Open, and we'd love to be available as a TTS option in Fonoster for users who want high quality multilingual voice synthesis on their voice apps.

The integration follows the exact same pattern as the existing Google, ElevenLabs, Deepgram, and Azure TTS engines, so it slots into the existing `TextToSpeechFactory` without any structural changes.

## What's added

**Engine:**
* `mods/apiserver/src/voice/tts/CambAi.ts`: new engine implementing `AbstractTextToSpeech` with chunked synthesis via the CAMB AI streaming API. Returns raw PCM16 (WAV header stripped) so it slots into the existing `sln16` output flow.
* `mods/apiserver/src/voice/tts/types.ts`: new `CambAiTtsConfig` type matching the existing config patterns.
* `mods/apiserver/src/voice/tts/TextToSpeechFactory.ts`: registration as `tts.cambai`.

**Database:**
* `mods/apiserver/schema.prisma`: added `CAMB_AI` to the `ProductVendor` enum.
* `mods/apiserver/migrations/20260410045143_add_cambai_vendor/migration.sql`: Prisma migration for the new enum value.
* `mods/apiserver/src/core/seed.ts`: seeded the `tts.cambai` product on startup.

**Config:**
* `config/integrations.example.json`: added a CAMB AI TTS integration example so users know what shape the credentials object takes.

**Tests:**
* `mods/apiserver/test/voice/tts/cambAi.test.ts`: Mocha + Chai + Sinon tests covering engine instantiation, payload format, WAV header stripping, error propagation, model overrides, schema validation, factory registration, and a live API integration test guarded by `CAMB_API_KEY`. 11 tests total, all passing.

## How it fits in

CAMB AI is a TTS-only provider, so it slots in next to the existing four engines registered in `TextToSpeechFactory`. Users configure it via `productRef: tts.cambai` in their integrations.json, exactly like they would for `tts.elevenlabs` or `tts.google`. No new abstractions, no changes to the Say verb or VoiceClient.

## Testing

```bash
LOGS_LEVEL=none NODE_ENV=development npx mocha --timeout 30000 \
  --node-option 'import=tsx' \
  'mods/apiserver/test/voice/tts/cambAi.test.ts'
```

Unit tests run with stubbed `fetch`. The integration test (`@voice/tts/CambAi - Integration > should synthesize speech with real API`) hits the real CAMB AI API when `CAMB_API_KEY` is set in the environment, otherwise it skips.

## About CAMB AI

CAMB AI provides MARS speech models with sub-150ms latency on `mars-flash`, voice cloning from short reference samples, and 16+ language support including English, Spanish, French, German, Japanese, Hindi, Portuguese, and Chinese. More info at https://camb.ai and https://studio.camb.ai.

Happy to iterate on anything: naming, code style, file locations, test coverage, the way the engine handles audio format conversion, or anything else. Thanks for considering this addition!