### PR TITLE
fix(sdk): attach trackCall stream listeners before caller iterates statusStream

### DIFF
--- a/mods/sdk/src/Calls.ts
+++ b/mods/sdk/src/Calls.ts
@@ -153,40 +153,48 @@ class Calls {
 
     const call = client.trackCall(trackCallRequest, this.client.getMetadata());
 
+    // Listeners must be attached synchronously, right after the stream is
+    // created. `statusStreamGenerator` below is an async generator, whose
+    // body (including any call.on(...) registrations placed inside it)
+    // only runs once the caller starts iterating it. If the stream emits
+    // "error" before that first iteration, Node's EventEmitter has no
+    // listener to call and throws, crashing the process instead of
+    // surfacing as a rejected promise the caller can catch.
+    const queue: Array<{ status: number }> = [];
+    let done = false;
+    let streamError: Error | null = null;
+
+    call.on("data", (response: DataResponse) => {
+      const data = response.toObject();
+      queue.push(data as { status: number });
+    });
+
+    call.on("end", () => {
+      done = true;
+    });
+
+    call.on("error", (err: Error) => {
+      streamError = err instanceof Error ? err : new Error(String(err));
+      done = true;
+    });
+
     async function* statusStreamGenerator(): AsyncGenerator<{
       status: DialStatus;
     }> {
-      const queue: Array<{ status: number }> = [];
-      let done = false;
-
-      call.on("data", (response: DataResponse) => {
-        const data = response.toObject();
-        queue.push(data as { status: number });
-      });
-
-      call.on("end", () => {
-        done = true;
-      });
-
-      call.on("error", () => {
-        done = true;
-        throw new Error("An error occurred while tracking the call");
-      });
-
       // eslint-disable-next-line no-loops/no-loops
-      while (!done) {
+      while (!done || queue.length > 0) {
         if (queue.length > 0) {
           const data = queue.shift()!;
-          if (!data) {
-            return;
-          }
-
           yield { status: dialStatusToString(data.status) } as {
             status: DialStatus;
           };
         } else {
           await new Promise<void>((resolve) => setTimeout(resolve, 50));
         }
+      }
+
+      if (streamError) {
+        throw streamError;
       }
     }
 

--- a/mods/sdk/test/calls.test.ts
+++ b/mods/sdk/test/calls.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EventEmitter } from "events";
+import * as chai from "chai";
+import { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinonChai from "sinon-chai";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe("@sdk[Calls]", function () {
+  it("should not crash when trackCall emits 'error' before the caller iterates statusStream", async function () {
+    // Arrange
+    const { Calls } = await import("../src/Calls");
+
+    const stream = new EventEmitter();
+
+    class CreateCallResponse {
+      getRef(): string {
+        return "00000000-0000-0000-0000-000000000000";
+      }
+    }
+    const createCallResponse = new CreateCallResponse();
+
+    const client = {
+      createCall: (
+        _req: unknown,
+        _metadata: unknown,
+        callback: (err: Error | null, res: unknown) => void
+      ) => callback(null, createCallResponse),
+      trackCall: () => stream
+    };
+
+    const fonosterClient = {
+      getCallsClient: () => client,
+      getMetadata: () => ({})
+    };
+
+    // Act
+    const calls = new Calls(fonosterClient as never);
+    const { statusStream } = await calls.createCall({
+      from: "+18287854037",
+      to: "+17853178070",
+      appRef: "00000000-0000-0000-0000-000000000000"
+    });
+
+    // Simulate the stream failing before the caller ever starts iterating
+    // (e.g. a "14 UNAVAILABLE: stream timeout" arriving while the caller is
+    // still doing other work). Previously this crashed the process because
+    // no "error" listener was attached yet.
+    stream.emit("error", new Error("14 UNAVAILABLE: stream timeout"));
+
+    // Assert: the error surfaces as a rejection from the async generator,
+    // not as an unhandled EventEmitter exception.
+    const iterate = async () => {
+      // eslint-disable-next-line no-loops/no-loops
+      for await (const _status of statusStream) {
+        // no-op
+      }
+    };
+
+    await expect(iterate()).to.be.rejectedWith(
+      "14 UNAVAILABLE: stream timeout"
+    );
+  });
+
+  it("should yield statuses received before consumption starts", async function () {
+    // Arrange
+    const { Calls } = await import("../src/Calls");
+
+    const stream = new EventEmitter();
+
+    class CreateCallResponse {
+      getRef(): string {
+        return "00000000-0000-0000-0000-000000000000";
+      }
+    }
+    const createCallResponse = new CreateCallResponse();
+
+    const client = {
+      createCall: (
+        _req: unknown,
+        _metadata: unknown,
+        callback: (err: Error | null, res: unknown) => void
+      ) => callback(null, createCallResponse),
+      trackCall: () => stream
+    };
+
+    const fonosterClient = {
+      getCallsClient: () => client,
+      getMetadata: () => ({})
+    };
+
+    // Act
+    const calls = new Calls(fonosterClient as never);
+    const { statusStream } = await calls.createCall({
+      from: "+18287854037",
+      to: "+17853178070",
+      appRef: "00000000-0000-0000-0000-000000000000"
+    });
+
+    stream.emit("data", { toObject: () => ({ status: 2 }) });
+    stream.emit("end");
+
+    const statuses = [];
+    // eslint-disable-next-line no-loops/no-loops
+    for await (const status of statusStream) {
+      statuses.push(status);
+    }
+
+    // Assert
+    expect(statuses).to.deep.equal([{ status: "ANSWER" }]);
+  });
+});


### PR DESCRIPTION
## Summary

`Calls.createCall()` creates the `trackCall` gRPC stream synchronously, but its `data`/`end`/`error` listeners were registered inside a lazily-evaluated async generator (`statusStreamGenerator`), which only runs once the caller starts iterating `statusStream`. If the stream emitted `error` before that first iteration (e.g. `14 UNAVAILABLE: stream timeout` under service degradation), Node's EventEmitter had no listener to call and threw synchronously — crashing the whole process. This happened regardless of any timeout/retry wrapper the caller applied around `createCall()`, because the crash originated from an unhandled `error` event inside `@grpc/grpc-js`, not from a rejected promise the caller's code path could catch.

- Listeners are now attached immediately, right after the stream is created — not inside the generator body.
- `error` is captured into a `streamError` variable instead of being thrown synchronously inside the listener callback; it's re-thrown from the generator as a normal rejection that `for await...of` (and any `try/catch` around it) can handle.
- Fixed a related bug in the same block: the original `while (!done)` loop condition could drop any status updates still queued at the moment `end` fired in the same tick; it's now `while (!done || queue.length > 0)`.

This mirrors the listener-attachment pattern already used in `Applications.evaluateIntelligenceStreamGenerator`.

Reported downstream as [fonoster/qcobro#27](https://github.com/fonoster/qcobro/issues/27) (Fonoster's own multilingual AI-voice collections platform, built on `@fonoster/sdk`), which hit this while dispatching outbound calls during a period of Fonoster service degradation. The QCobro team is verifying the compiled fix as a hotfix bind-mount in their own deployment; will report back here once that's confirmed.

## Test plan

- [x] Added `mods/sdk/test/calls.test.ts` — a regression test that emits a stream `error` before the caller starts iterating `statusStream` and asserts it surfaces as a rejection rather than crashing the process (confirmed this hangs/crashes on the pre-fix code), plus a test that queued statuses are still yielded correctly.
- [x] `mods/sdk`: `tsc --noEmit`, `eslint`, and the full `mods/sdk` unit test suite pass.
- [x] Full repo test suite (`npm test`, 199 passing) via the pre-push hook.
- [ ] Downstream production verification in QCobro (pending)