### PR TITLE
fix(autopilot): surface events-hook webhook status/errors in logs

### DIFF
--- a/mods/autopilot/src/sendConversationEndedEvent.ts
+++ b/mods/autopilot/src/sendConversationEndedEvent.ts
@@ -61,6 +61,13 @@ export async function sendConversationEndedEvent(
     ...(recordingUrl && { recordingUrl })
   };
 
+  logger.verbose("dispatching conversation.ended webhook", {
+    url: parsedEventsHook.url,
+    eventType: params.eventType,
+    appRef,
+    callRef
+  });
+
   try {
     await sendHttpRequest({
       url: parsedEventsHook.url!,
@@ -70,11 +77,13 @@ export async function sendConversationEndedEvent(
       params
     });
   } catch (e) {
-    logger.warn("sending event", {
+    logger.error("failed to send conversation.ended webhook", {
       url: parsedEventsHook.url,
       method: AllowedHttpMethod.POST,
       waitForResponse: false,
-      params
+      appRef,
+      callRef,
+      error: e instanceof Error ? e.message : e
     });
   }
 }

--- a/mods/common/src/utils/sendHttpRequest.ts
+++ b/mods/common/src/utils/sendHttpRequest.ts
@@ -69,7 +69,23 @@ async function sendHttpRequest(request: {
   });
 
   if (!waitForResponse && effectiveMethod === AllowedHttpMethod.POST) {
-    setTimeout(() => fetch(effectiveUrl, options), 0);
+    setTimeout(() => {
+      fetch(effectiveUrl, options)
+        .then((res) => {
+          logger.verbose(
+            `fire-and-forget request to ${effectiveUrl} completed`,
+            {
+              status: res.status,
+              ok: res.ok
+            }
+          );
+        })
+        .catch((error) => {
+          logger.error(`fire-and-forget request to ${effectiveUrl} failed`, {
+            error: error instanceof Error ? error.message : error
+          });
+        });
+    }, 0);
     return { result: "success" };
   } else {
     const response = await fetch(effectiveUrl, options);


### PR DESCRIPTION
## Description

The events-hook webhook send (used e.g. for `conversation.ended`) was completely unobservable. `sendHttpRequest`'s non-blocking POST path (`waitForResponse: false`) fired the `fetch` inside a `setTimeout` and discarded the resulting promise entirely — no status code, no connection error, nothing. From the logs there was no way to tell whether the webhook fired at all, let alone what the consumer returned. On top of that, `sendConversationEndedEvent`'s `catch` block logged a static message without the actual error object, so even failures inside that wrapper were opaque.

This is a pure observability fix:

- `mods/common/src/utils/sendHttpRequest.ts` — the fire-and-forget branch now attaches `.then()/.catch()` to the previously-discarded `fetch`, logging the response status/ok and any connection error. Timing (still fired via `setTimeout(..., 0)`) and the function's return shape (`{ result: "success" }`) are unchanged.
- `mods/autopilot/src/sendConversationEndedEvent.ts` — added a pre-send log with the target url/eventType/appRef/callRef, and fixed the `catch` block to log the actual error at `error` level instead of swallowing it.

New log lines an operator can grep for:

- `dispatching conversation.ended webhook` (verbose, before send)
- `fire-and-forget request to <url> completed` (verbose, with `status`/`ok`)
- `fire-and-forget request to <url> failed` (error, with the connection error)
- `failed to send conversation.ended webhook` (error, if the wrapper itself throws)

This intentionally does **not** switch `sendConversationEndedEvent` to `waitForResponse: true` — the events-hook consumer's response doesn't match `sendHttpRequest`'s expected response schema, so awaiting it would throw. This PR only adds non-blocking logging around the existing fire-and-forget path.

**Follow-up (separate, not fixed here):** the autopilot only ever sends `conversation.ended`. There is no `conversation.started` sender, even though the events-hook schema and subscriber side already support that event type. Flagging as a known gap for a future change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `mods/common` and `mods/autopilot` build and lint clean.
- Full unit test suite passes locally (`npm test`, 199 passing, 3 pending, run via the repo's pre-push hook).
- No behavior change to timing or return values — verified by inspecting the diff: the `setTimeout(..., 0)` fire-and-forget dispatch and `{ result: "success" }` return are untouched; only `.then()/.catch()` logging was attached to the previously-discarded fetch promise.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
