### PR TITLE
fix(autopilot): replace retired Gemini 2.0 Flash default (#857)

### DIFF
--- a/mods/autopilot/.intro.md
+++ b/mods/autopilot/.intro.md
@@ -85,7 +85,7 @@ The Autopilot supports multiple language model providers. The following is a lis
 
 | Provider   | Description                                                    | Supported models
 |------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| Google     | Google provides various Gemini models for conversational AI    | `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
+| Google     | Google provides various Gemini models for conversational AI    | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
 | OpenAI     | OpenAI provides various GPT models for conversational AI       | `gpt-4o`, `gpt-4o-mini`, `gpt-3.5-turbo`, `gpt-4-turbo`                                    |
 | Groq       | Groq offers high-performance AI models optimized for speed     | `llama-3.3-70b-versatile`                                                                  |
 | Ollama     | Self-hosted Ollama models                                      | `llama3-groq-tool-use`                                                                     |

--- a/mods/autopilot/src/models/google/Google.ts
+++ b/mods/autopilot/src/models/google/Google.ts
@@ -22,6 +22,7 @@ import { convertToolToLangchainTool } from "../../tools/convertToolToLangchainTo
 import { Voice } from "../../voice";
 import { AbstractLanguageModel } from "../AbstractLanguageModel";
 import { TelephonyContext } from "../types";
+import { resolveGoogleModel } from "./resolveGoogleModel";
 import { GoogleParams } from "./types";
 
 const LANGUAGE_MODEL_NAME = "llm.google";
@@ -33,7 +34,8 @@ class Google extends AbstractLanguageModel {
     telephonyContext: TelephonyContext
   ) {
     const model = new ChatGoogleGenerativeAI({
-      ...params
+      ...params,
+      model: resolveGoogleModel(params.model)
     }).bindTools(
       params.tools.map(convertToolToLangchainTool)
     ) as unknown as BaseChatModel;

--- a/mods/autopilot/src/models/google/index.ts
+++ b/mods/autopilot/src/models/google/index.ts
@@ -18,4 +18,6 @@
  */
 export * from "./Google";
 
+export * from "./resolveGoogleModel";
+
 export * from "./types";

--- a/mods/autopilot/src/models/google/resolveGoogleModel.ts
+++ b/mods/autopilot/src/models/google/resolveGoogleModel.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getLogger } from "@fonoster/logger";
+import { GoogleModel } from "./types";
+
+const logger = getLogger({ service: "autopilot", filePath: __filename });
+
+/**
+ * Gemini 2.0 Flash models were shut down by Google on 2026-06-01.
+ * Remap persisted configs so Autopilot does not 404 on generateContent.
+ */
+const RETIRED_GOOGLE_MODELS: Partial<Record<string, GoogleModel>> = {
+  "gemini-2.0-flash": GoogleModel.GEMINI_2_5_FLASH,
+  "gemini-2.0-flash-lite": GoogleModel.GEMINI_2_5_FLASH_LITE
+};
+
+function resolveGoogleModel(model: string): string {
+  const replacement = RETIRED_GOOGLE_MODELS[model];
+  if (!replacement) {
+    return model;
+  }
+
+  logger.warn("remapping retired Google Gemini model", {
+    from: model,
+    to: replacement
+  });
+  return replacement;
+}
+
+export { resolveGoogleModel };

--- a/mods/autopilot/src/models/google/types.ts
+++ b/mods/autopilot/src/models/google/types.ts
@@ -19,8 +19,6 @@
 import { BaseModelParams } from "../types";
 
 enum GoogleModel {
-  GEMINI_2_0_FLASH = "gemini-2.0-flash",
-  GEMINI_2_0_FLASH_LITE = "gemini-2.0-flash-lite",
   GEMINI_2_5_PRO = "gemini-2.5-pro",
   GEMINI_2_5_FLASH = "gemini-2.5-flash",
   GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite",

--- a/mods/autopilot/test/models/resolveGoogleModel.test.ts
+++ b/mods/autopilot/test/models/resolveGoogleModel.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from "chai";
+import { resolveGoogleModel } from "../../src/models/google/resolveGoogleModel";
+import { GoogleModel } from "../../src/models/google/types";
+
+describe("@autopilot/resolveGoogleModel", () => {
+  it("remaps retired gemini-2.0-flash to gemini-2.5-flash", () => {
+    expect(resolveGoogleModel("gemini-2.0-flash")).to.equal(
+      GoogleModel.GEMINI_2_5_FLASH
+    );
+  });
+
+  it("remaps retired gemini-2.0-flash-lite to gemini-2.5-flash-lite", () => {
+    expect(resolveGoogleModel("gemini-2.0-flash-lite")).to.equal(
+      GoogleModel.GEMINI_2_5_FLASH_LITE
+    );
+  });
+
+  it("leaves supported Gemini models unchanged", () => {
+    expect(resolveGoogleModel(GoogleModel.GEMINI_2_5_FLASH)).to.equal(
+      GoogleModel.GEMINI_2_5_FLASH
+    );
+    expect(resolveGoogleModel(GoogleModel.GEMINI_3_FLASH_PREVIEW)).to.equal(
+      GoogleModel.GEMINI_3_FLASH_PREVIEW
+    );
+  });
+});

--- a/mods/dashboard/src/applications/pages/create-application/create-application.const.tsx
+++ b/mods/dashboard/src/applications/pages/create-application/create-application.const.tsx
@@ -177,8 +177,6 @@ export const LANGUAGE_MODEL_GROQ_MODELS = [
 ];
 
 export const LANGUAGE_MODEL_GOOGLE_MODELS = [
-  { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
-  { value: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
   { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
@@ -249,7 +247,7 @@ export const APPLICATIONS_DEFAULT_INITIAL_VALUES: Schema = {
       },
       languageModel: {
         provider: LanguageModelProvider.GOOGLE,
-        model: "gemini-2.0-flash",
+        model: "gemini-2.5-flash",
         temperature: 0.2,
         maxTokens: 240,
         tools: []


### PR DESCRIPTION
## Summary
- Fixes #857: Autopilot crashes with `GoogleGenerativeAIFetchError` 404 because Google shut down `gemini-2.0-flash` / `gemini-2.0-flash-lite` on 2026-06-01.
- Updates the dashboard Autopilot default Google model to `gemini-2.5-flash` and removes the retired 2.0 models from the supported model list / `GoogleModel` enum.
- Remaps persisted configs that still reference retired Gemini 2.0 Flash IDs to supported 2.5 equivalents at Autopilot startup so existing applications do not keep 404ing.

## Test plan
- [x] `npx mocha --timeout 30000 mods/autopilot/test/models/resolveGoogleModel.test.ts` (3 passing)
- [x] Full pre-push `npm test` suite (202 passing, 3 pending)
- [ ] Create a new Autopilot application with the Google provider and confirm the default model is `gemini-2.5-flash`
- [ ] Run Autopilot against a Google GenAI key with an app still configured as `gemini-2.0-flash` and confirm generateContent succeeds after remap (warn log expected)


Made with [Cursor](https://cursor.com)