### PR TITLE
fix(dashboard): break infinite render loop in egress-policies FormField

### DIFF
--- a/mods/dashboard/src/domains/pages/create-domain/create-domain.form.tsx
+++ b/mods/dashboard/src/domains/pages/create-domain/create-domain.form.tsx
@@ -21,12 +21,13 @@ import {
   Form,
   FormControl,
   FormField,
+  FormFieldContext,
   FormItem
 } from "~/core/components/design-system/forms";
 import { Input } from "~/core/components/design-system/ui/input/input";
 import { FormRoot } from "~/core/components/design-system/forms/form-root";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useState, useEffect, useMemo } from "react";
+import { useCallback, useState, useMemo } from "react";
 import { schema, type Schema } from "./create-domain.schema";
 import { useAcls } from "~/acls/services/acls.service";
 import { Select } from "~/core/components/design-system/ui/select/select";
@@ -79,12 +80,7 @@ export function CreateDomainForm({
   const [isRulesModalOpen, setIsRulesModalOpen] = useState(false);
   const [isDomainAclsModalOpen, setIsDomainAclsModalOpen] = useState(false);
 
-  const {
-    data: aclsData,
-    isLoading: isAclsLoading,
-    refetch: refetchAcls
-  } = useAcls();
-  const [acls, setAcls] = useState<Acl[]>([]);
+  const { data: acls, isLoading: isAclsLoading } = useAcls();
 
   const { data: numbers, isLoading: isNumbersLoading } = useNumbers();
 
@@ -165,19 +161,10 @@ export function CreateDomainForm({
 
   const handleAclFormSubmit = useCallback(
     (newAcl: Acl) => {
-      // Add the new ACL to the local list and select it
-      setAcls((prev) => [...(prev || []), newAcl]);
       form.setValue("accessControlListRef", newAcl.ref);
     },
     [form]
   );
-
-  // Keep local ACLs in sync with remote data
-  useEffect(() => {
-    if (aclsData) {
-      setAcls(aclsData);
-    }
-  }, [aclsData]);
 
   /** Sync form state with FormContext */
   useFormContextSync(form, onSubmit, isEdit);
@@ -259,50 +246,60 @@ export function CreateDomainForm({
             )}
           />
 
-          <FormField
-            control={form.control}
-            name="egressPolicies"
-            render={() => (
-              <FormItem>
-                <FormControl>
-                  <Box
-                    sx={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "12px"
+          {/*
+            Provides FormFieldContext directly instead of using <FormField
+            name="egressPolicies">. FormField wraps RHF's <Controller>, and
+            useFieldArray (above) already subscribes to this same field
+            path -- a parallel Controller subscription for a field whose
+            render prop doesn't even consume the `field` argument caused
+            "Maximum update depth exceeded" (React error #185) on mount, a
+            known react-hook-form footgun (useFieldArray + a separate
+            Controller on the same array path). Select still needs
+            FormFieldContext internally (via useFormField(), used by
+            FormControl too), so we supply just that context, without the
+            Controller that caused the loop. FormItem/FormControl are
+            otherwise unchanged from the original markup.
+          */}
+          <FormFieldContext.Provider value={{ name: "egressPolicies" }}>
+            <FormItem>
+              <FormControl>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "12px"
+                  }}
+                >
+                  {/* Read-only Select showing current rules */}
+                  <Select
+                    label="Egress Rules"
+                    placeholder="Click below to add rules (e.g., .*)."
+                    multiple
+                    value={selectValues}
+                    options={selectOptions}
+                    disabled
+                    onChange={(event) => {
+                      const selectedValues = event.target.value as string[];
+                      // Update the form state with selected values
+                      form.setValue(
+                        "egressPolicies",
+                        selectedValues.map((value) => {
+                          const [rule, numberRef] = value.split(":");
+                          return { rule, numberRef };
+                        })
+                      );
                     }}
-                  >
-                    {/* Read-only Select showing current rules */}
-                    <Select
-                      label="Egress Rules"
-                      placeholder="Click below to add rules (e.g., .*)."
-                      multiple
-                      value={selectValues}
-                      options={selectOptions}
-                      disabled
-                      onChange={(event) => {
-                        const selectedValues = event.target.value as string[];
-                        // Update the form state with selected values
-                        form.setValue(
-                          "egressPolicies",
-                          selectedValues.map((value) => {
-                            const [rule, numberRef] = value.split(":");
-                            return { rule, numberRef };
-                          })
-                        );
-                      }}
-                    />
+                  />
 
-                    {/* Modal trigger to open rule creation */}
-                    <ModalTrigger
-                      onClick={() => setIsRulesModalOpen(true)}
-                      label="Create New Egress Rule"
-                    />
-                  </Box>
-                </FormControl>
-              </FormItem>
-            )}
-          />
+                  {/* Modal trigger to open rule creation */}
+                  <ModalTrigger
+                    onClick={() => setIsRulesModalOpen(true)}
+                    label="Create New Egress Rule"
+                  />
+                </Box>
+              </FormControl>
+            </FormItem>
+          </FormFieldContext.Provider>
         </FormRoot>
       </Form>
 


### PR DESCRIPTION
## Description

The Create/Edit Domain form crashes on mount with React error #185
("Maximum update depth exceeded"). The `egressPolicies` field is wrapped in
`<FormField name="egressPolicies">` (react-hook-form's `Controller`) while
`useFieldArray` in the same component already subscribes to that same field
path — a parallel `Controller` subscription on a `useFieldArray` path is a
known react-hook-form footgun that causes a render loop, and the render prop
here didn't even use the `field` argument it was given, so the `Controller`
wasn't adding anything but the loop.

This fix supplies `FormFieldContext.Provider` directly — the part
`Select`/`FormControl` actually need via `useFormField()` — without going
through `Controller`. Markup (`FormItem`/`FormControl`) is unchanged.

As a secondary cleanup in the same file, a redundant local `acls` `useState`
+ `useEffect` mirror of `useAcls()` query data is removed in favour of using
the query data directly.

**Note for reviewers:** three other places in the dashboard use the same
parallel-Controller-on-a-`useFieldArray`-path pattern (`create-acl.form.tsx`
`rules`, `create-trunk.form.tsx` `uris`, `tools-section.tsx` `…tools`), and
at least `create-trunk` does not loop in production. So the parallel
`Controller` alone doesn't appear to be a sufficient trigger on its own —
it's possible the co-occurring `acls` state mirror removed here was a
necessary part of the trigger, or something else specific to this
component. I haven't isolated the exact minimal repro, only confirmed this
patch fixes the crash. Flagging in case it's obvious to someone more familiar
with this code, and in case those other three sites are worth a second look
as latent instances of the same class of bug.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified on a real self-hosted deployment: before the fix, opening
Create/Edit Domain crashed immediately on mount; after the fix, the form
mounts, the egress-policies field works, and domain creation/editing
completes successfully end-to-end. I have not run the project's own test
suite against this change.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
