### PR TITLE
fix(dashboard): stop create-trunk.hook clobbering sendRegister default

### DIFF
--- a/mods/dashboard/src/trunks/pages/create-trunk/create-trunk.hook.tsx
+++ b/mods/dashboard/src/trunks/pages/create-trunk/create-trunk.hook.tsx
@@ -55,7 +55,16 @@ export const useCreateTrunk = () => {
     async (data: Schema, disableNavigation?: boolean) => {
       try {
         Logger.debug("Creating trunk with data:", data);
-        const trunks = await mutateAsync({ sendRegister: true, ...data });
+        // `sendRegister` must always reach the backend as `true` -- its
+        // schema requires the field present (no default), and gRPC omits
+        // `false` (the zero value) from the wire entirely, so the
+        // apiserver sees it as missing and rejects the request with
+        // "Required at sendRegister". The form's checkbox for this is
+        // disabled ("coming soon"), pinned to `false` in defaultValues,
+        // so spreading `...data` after the `true` default clobbered it on
+        // every submission. `true` here must win, matching how the CLI
+        // (mods/ctl/src/commands/sipnet/trunks/create.ts) always sends it.
+        const trunks = await mutateAsync({ ...data, sendRegister: true });
         toast("Trunk created successfully!");
 
         if (disableNavigation) return trunks;


### PR DESCRIPTION
## Description

Every Create Trunk submission through the dashboard fails with
`Required at "sendRegister"`, regardless of what's actually filled in. Trunk
creation via the dashboard is unusable.

Three things combine to cause this:

1. **Backend**: apiserver's `createTrunkRequestSchema` requires
   `sendRegister: z.boolean()` with no default.
2. **Wire**: gRPC omits `false` (the zero value) from the payload entirely,
   so a `false` value arrives at apiserver as a genuinely *missing* field,
   and zod rejects it as "Required" — not as an actual validation failure on
   anything the user controls.
3. **Dashboard**: the Create Trunk form's "Send SIP Register requests for
   this trunk" checkbox is hardcoded `disabled` ("coming soon") and pinned
   to `false` in the form's own `defaultValues`. The submit hook
   (`create-trunk.hook.tsx`) was spreading
   `{ sendRegister: true, ...data }` — the trailing `...data` always
   clobbers the `true` default with the pinned `false`, so the field is
   always sent as `false`, which per point 2 above means it's always sent as
   *nothing at all*.

Fonoster's own CLI (`mods/ctl/src/commands/sipnet/trunks/create.ts`) always
hardcodes `sendRegister: true` and never hits this, so only the dashboard
path was broken.

This PR fixes the immediate breakage by reordering the spread to
`{ ...data, sendRegister: true }`, matching the CLI's behaviour. The
checkbox stays cosmetically present but non-functional, same as before this
change — I didn't touch that, since it looked like an intentional
"coming soon" state rather than part of this bug.

Worth considering separately (raising here rather than silently expanding
scope): the more robust backend-side fix might be
`sendRegister: z.boolean().default(true)`, or otherwise making the schema
tolerant of gRPC's zero-value omission, so this class of bug can't recur for
other required booleans. Happy to open that as a follow-up if it's wanted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified on a real self-hosted deployment: before the fix, every Create
Trunk submission failed with `Required at "sendRegister"` regardless of
input; after the fix, trunk creation succeeds through the dashboard. I have
not run the project's own test suite against this change.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] (rest left unchecked — not verified)
