### PR TITLE
fix(sipnet): restore proto3 zero values dropped from trunk requests

### DIFF
--- a/mods/common/src/validators/sipnet/trunks.ts
+++ b/mods/common/src/validators/sipnet/trunks.ts
@@ -19,6 +19,7 @@
 import { Transport } from "@fonoster/types";
 import * as Validator from "validator";
 import { z } from "zod";
+import { POSITIVE_INTEGER_MESSAGE } from "../../messages";
 import { nameSchema } from "../common";
 
 const hostOrIPSchema = z
@@ -27,19 +28,29 @@ const hostOrIPSchema = z
     message: "Must be a valid IP or FQDN"
   });
 
+// Scalars holding their zero value (`false`, `0`) are not serialized by proto3,
+// and the loader is configured with `defaults: false` (see `utils/createService`),
+// so they reach the handler as missing rather than as the value the client sent.
+// Declaring the zero value as the schema default restores what the wire dropped,
+// instead of rejecting a well-formed request with `Required at "<field>"`.
 const createTrunkRequestSchema = z.object({
   name: nameSchema,
-  sendRegister: z.boolean(),
+  sendRegister: z.boolean().default(false),
   inboundUri: hostOrIPSchema,
   uris: z.array(
     z.object({
       host: hostOrIPSchema,
-      port: z.number(),
+      // Zero is not a usable SIP port, so this default never stands on its own;
+      // it exists so a missing or zero port fails with an accurate message.
+      port: z
+        .number()
+        .positive({ message: POSITIVE_INTEGER_MESSAGE })
+        .default(0),
       transport: z.nativeEnum(Transport, { message: "Invalid transport" }),
       user: z.string().optional(),
-      weight: z.number(),
-      priority: z.number(),
-      enabled: z.boolean()
+      weight: z.number().default(0),
+      priority: z.number().default(0),
+      enabled: z.boolean().default(false)
     })
   )
 });

--- a/mods/common/test/validators/sipnet/trunks.test.ts
+++ b/mods/common/test/validators/sipnet/trunks.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Transport } from "@fonoster/types";
+import { expect } from "chai";
+import { createTrunkRequestSchema } from "../../../src";
+
+describe("@apiserver[common/validators/sipnet/trunks]", function () {
+  it("checks the zero values dropped by proto3 are restored", async function () {
+    // Arrange
+    // A request as it reaches the handler after the wire dropped every scalar
+    // the client set to its zero value: sendRegister, weight, priority, enabled
+    const createTrunkRequest = {
+      name: "My Trunk",
+      inboundUri: "sip.fonoster.io",
+      uris: [
+        {
+          host: "sip.provider.net",
+          port: 5060,
+          transport: Transport.TCP
+        }
+      ]
+    };
+
+    // Act
+    const result = createTrunkRequestSchema.parse(createTrunkRequest);
+
+    // Assert
+    expect(result.sendRegister).to.be.false;
+    expect(result.uris[0].weight).to.be.equal(0);
+    expect(result.uris[0].priority).to.be.equal(0);
+    expect(result.uris[0].enabled).to.be.false;
+  });
+
+  it("checks the values sent by the client are left untouched", async function () {
+    // Arrange
+    const createTrunkRequest = {
+      name: "My Trunk",
+      sendRegister: true,
+      inboundUri: "sip.fonoster.io",
+      uris: [
+        {
+          host: "sip.provider.net",
+          port: 5061,
+          transport: Transport.TLS,
+          user: "user",
+          weight: 10,
+          priority: 1,
+          enabled: true
+        }
+      ]
+    };
+
+    // Act
+    const result = createTrunkRequestSchema.parse(createTrunkRequest);
+
+    // Assert
+    expect(result.sendRegister).to.be.true;
+    expect(result.uris[0].port).to.be.equal(5061);
+    expect(result.uris[0].weight).to.be.equal(10);
+    expect(result.uris[0].priority).to.be.equal(1);
+    expect(result.uris[0].enabled).to.be.true;
+  });
+
+  it("checks a uri without a usable port reports the port, not a missing field", async function () {
+    // Arrange
+    const createTrunkRequest = {
+      name: "My Trunk",
+      inboundUri: "sip.fonoster.io",
+      uris: [
+        {
+          host: "sip.provider.net",
+          transport: Transport.TCP
+        }
+      ]
+    };
+
+    // Act
+    const result = createTrunkRequestSchema.safeParse(createTrunkRequest);
+    const issues = result.success ? [] : result.error.issues;
+
+    // Assert
+    expect(result.success).to.be.false;
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].path).to.deep.equal(["uris", 0, "port"]);
+    expect(issues[0].message).to.be.equal("Must be a positive number");
+  });
+});


### PR DESCRIPTION
## Description

Creating a SIP trunk fails for every client, with an error that names a field the
client did in fact send:

```
Required at "sendRegister"
Required at "uris[0].weight"; Required at "uris[0].priority"; Required at "uris[0].enabled"
```

proto3 does not put a scalar holding its zero value on the wire, and the loader
in `mods/common/src/utils/createService.ts` is configured with `defaults: false`,
so those fields are never reconstructed on the receiving side. They arrive at the
handler genuinely absent. `createTrunkRequestSchema` declared them required, so a
well-formed request carrying `sendRegister: false` or `priority: 0` was rejected
as if the field had been left out.

The same request proves the mechanism: `port: 5060` arrives, while `weight: 0`,
`priority: 0` and `enabled: false` in the *same* URI object do not — the only
difference is whether the value is the type's zero.

This change declares each affected field's proto3 zero value as the schema
default, which reconstructs exactly what the wire dropped, without changing the
loader's `defaults` flag (that would affect every service).

`port` additionally rejects zero via the existing `POSITIVE_INTEGER_MESSAGE`
idiom used by `validators/sipnet/agents.ts` — zero has no meaning as a SIP port,
so a missing port is now reported accurately against `uris[0].port` instead of
being accepted and stored as `0`. `weight` and `priority` get no such guard:
zero is a legal SRV-style weight/priority, and enforcing a range is Routr's
decision, not this schema's.

**On `sendRegister: false` vs `true`.** #869 diagnoses the same wire behaviour
and suggests `z.boolean().default(true)` as a possible backend fix. I went with
`false` instead:

- `false` is what the dashboard sends, and has been since 5f2d46dee
  (`fix(create-trunk): update default sendRegister value to false`); the
  checkbox is `disabled` in the form, so a user cannot ask for anything else.
- `true` would silently enable registration on a trunk the client explicitly
  declared as non-registering, and would make an IP-authenticated trunk
  impossible to create through the API at all — `false` could never reach the
  handler.
- `false` is also simply what proto3 means here: the field was sent, with the
  value `false`.

This PR does not touch `create-trunk.hook.tsx` — that dashboard-side fix is
#869's, and the two do not conflict. This change repairs trunk creation on its
own (the hook's `{ sendRegister: true, ...data }` is dead code either way), and
still behaves correctly if #869 lands, since an explicit `true` is non-zero and
travels normally.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests added in `mods/common/test/validators/sipnet/trunks.test.ts`
(first tests for the sipnet validators):

- zero values omitted by the wire are restored (`sendRegister` → `false`,
  `weight`/`priority` → `0`, `enabled` → `false`);
- values the client actually sent are left untouched;
- a URI without a usable port reports `uris[0].port` with
  `Must be a positive number`, not a missing field.

`npm test` at the repo root: **202 passing, 0 failing.**

Manually verified against a local stack (apiserver + dashboard + routr +
postgres, `compose.yaml`):

| Case | Before | After |
|---|---|---|
| Trunk, inbound URI only | `Required at "sendRegister"` | created, `Send Register: false` |
| Trunk + outbound URI (form defaults) | `Required at "uris[0].weight"; ...priority; ...enabled` | created |
| Trunk + outbound URI, `priority: 0` | rejected by the schema as missing | reaches Routr, which rejects it with `INVALID_ARGUMENT: the priority must be a valid integer` |

The third row is the intended layering change rather than a full fix for that
input: the request is no longer misreported as incomplete by Fonoster and now
reaches the component that owns the range rule. Routr rejecting `priority: 0`
looks like a separate issue (its own `isValidPriority` documents `0..65535`) and
is out of scope here.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
