### PR TITLE
fix(identity): catch unhandled rejection in verification email send

### DIFF
--- a/mods/identity/src/verification/createSendVerificationCode.ts
+++ b/mods/identity/src/verification/createSendVerificationCode.ts
@@ -23,12 +23,15 @@ import {
   Validators as V,
   withErrorHandlingAndValidation
 } from "@fonoster/common";
+import { getLogger } from "@fonoster/logger";
 import { Prisma } from "../db";
 import { IdentityConfig } from "../exchanges";
 import { createGenerateVerificationCode } from "../utils/createGenerateVerificationCode";
 import { sendVerificationEmail } from "./sendVerificationEmail";
 import { sendVerificationMessage } from "./sendVerificationMessage";
 import { ContactType, SendVerificationCodeRequest } from "./types";
+
+const logger = getLogger({ service: "identity", filePath: __filename });
 
 function createSendVerificationCode(
   prisma: Prisma,
@@ -54,6 +57,11 @@ function createSendVerificationCode(
       sendVerificationEmail(sendEmail, {
         recipient: request.value,
         verificationCode
+      }).catch((error) => {
+        logger.error("failed to send verification email", {
+          recipient: request.value,
+          error: error instanceof Error ? error.message : error
+        });
       });
     } else {
       await sendVerificationMessage(sendSms, {


### PR DESCRIPTION
## Summary
- `createSendVerificationCode` fired `sendVerificationEmail` without `await` or a `.catch()`, unlike the SMS branch which is properly awaited.
- When nodemailer's `transporter.sendMail` rejected (e.g. bad SMTP credentials causing a `535` auth error from Gmail), the rejection had nothing attached to it, becoming an unhandled promise rejection that crashed the whole process — even though `callback(null)` had already told the caller the request succeeded.
- Attach a `.catch()` that logs the failure instead, matching the fire-and-forget logging pattern already used in `sendConversationEndedEvent`/`sendHttpRequest`.

## Test plan
- [x] `tsc --noEmit` on `mods/identity` passes
- [x] Full mocha suite passes (199 passing, 3 pending) via pre-push hook