### PR TITLE
fix(autopilot): send conversation.started events-hook webhook at call start

### DIFF
--- a/mods/autopilot/src/handleVoiceRequest.ts
+++ b/mods/autopilot/src/handleVoiceRequest.ts
@@ -41,6 +41,7 @@ import {
   EventsHook,
   sendConversationEndedEvent
 } from "./sendConversationEndedEvent";
+import { sendConversationStartedEvent } from "./sendConversationStartedEvent";
 import Autopilot, {
   ConversationProvider,
   ConversationSettings,
@@ -137,6 +138,17 @@ async function handleVoiceRequest(req: VoiceRequest, res: VoiceResponse) {
     });
 
     await autopilot.start();
+
+    if (assistantConfig.eventsHook?.url) {
+      await sendConversationStartedEvent(
+        assistantConfig.eventsHook as EventsHook,
+        {
+          appRef,
+          callRef,
+          phone: ingressNumber
+        }
+      );
+    }
 
     res.on(StreamEvent.END, async () => {
       autopilot.stop();

--- a/mods/autopilot/src/sendConversationStartedEvent.ts
+++ b/mods/autopilot/src/sendConversationStartedEvent.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2025 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/fonoster
+ *
+ * This file is part of Fonoster
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  AllowedHttpMethod,
+  EventsHookAllowedEvents,
+  eventsHookSchema,
+  sendHttpRequest
+} from "@fonoster/common";
+import { getLogger } from "@fonoster/logger";
+import { EventsHook } from "./sendConversationEndedEvent";
+
+const logger = getLogger({ service: "autopilot", filePath: __filename });
+
+export async function sendConversationStartedEvent(
+  eventsHook: EventsHook,
+  data: {
+    appRef: string;
+    callRef: string;
+    phone: string;
+  }
+) {
+  const { phone, appRef, callRef } = data;
+
+  if (
+    !eventsHook?.events.includes(
+      EventsHookAllowedEvents.CONVERSATION_STARTED
+    ) &&
+    !eventsHook?.events.includes(EventsHookAllowedEvents.ALL)
+  ) {
+    return;
+  }
+
+  const parsedEventsHook = eventsHookSchema.parse(eventsHook);
+  const params = {
+    eventType: EventsHookAllowedEvents.CONVERSATION_STARTED,
+    appRef,
+    callRef,
+    phone
+  };
+
+  logger.verbose("dispatching conversation.started webhook", {
+    url: parsedEventsHook.url,
+    eventType: params.eventType,
+    appRef,
+    callRef
+  });
+
+  try {
+    await sendHttpRequest({
+      url: parsedEventsHook.url!,
+      method: AllowedHttpMethod.POST,
+      headers: parsedEventsHook.headers,
+      waitForResponse: false,
+      params
+    });
+  } catch (e) {
+    logger.error("failed to send conversation.started webhook", {
+      url: parsedEventsHook.url,
+      method: AllowedHttpMethod.POST,
+      waitForResponse: false,
+      appRef,
+      callRef,
+      error: e instanceof Error ? e.message : e
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- `mods/autopilot/src/sendConversationEndedEvent.ts` had no `conversation.started` counterpart, even though `EventsHookAllowedEvents.CONVERSATION_STARTED` is already defined in the events-hook schema and downstream consumers (e.g. QCobro's `createIngestVoiceEvent`) already handle it to record a `startedAt` partial-progress marker.
- `handleVoiceRequest.ts` only ever sent the ended event, on `StreamEvent.END`, so the started branch was effectively dead code on the wire — a call that never ends cleanly retains no started-event enrichment downstream.
- Adds `sendConversationStartedEvent.ts`, mirroring the ended-event sender (same gating on `eventsHook.events`, same fire-and-forget `sendHttpRequest` + verbose/error logging), sending only `appRef`/`callRef`/`phone`.
- Invokes it in `handleVoiceRequest.ts` right after `autopilot.start()` succeeds, gated on `assistantConfig.eventsHook?.url` just like the ended-event call.

Fixes fonoster/qcobro#59

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Full unit test suite passes (199 passing, 3 pending) via pre-push hook